### PR TITLE
Convert Next.js config to JavaScript module

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -24,7 +24,7 @@ COPY package.json package-lock.json ./
 RUN npm ci --omit=dev && npm cache clean --force
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public
-COPY --from=builder /app/next.config.ts ./next.config.ts
+COPY --from=builder /app/next.config.mjs ./next.config.mjs
 RUN chown -R node:node /app
 USER node
 EXPOSE 3000

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  /* config options here */
+};
+
+export default nextConfig;

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,0 @@
-import type { NextConfig } from "next";
-
-const nextConfig: NextConfig = {
-  /* config options here */
-};
-
-export default nextConfig;


### PR DESCRIPTION
## Summary
- replace the TypeScript-based Next.js configuration with a JavaScript `next.config.mjs` that uses JSDoc typing
- update the Dockerfile runtime stage to copy the new config filename

## Testing
- not run (Docker is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e2c41a8c808323a07c1c0a14bbd504