### PR TITLE
Switch Next.js config to CommonJS module

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -24,7 +24,7 @@ COPY package.json package-lock.json ./
 RUN npm ci --omit=dev && npm cache clean --force
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public
-COPY --from=builder /app/next.config.ts ./next.config.ts
+COPY --from=builder /app/next.config.js ./next.config.js
 RUN chown -R node:node /app
 USER node
 EXPOSE 3000

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,8 @@
+// @ts-check
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  /* config options here */
+};
+
+module.exports = nextConfig;

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,0 @@
-import type { NextConfig } from "next";
-
-const nextConfig: NextConfig = {
-  /* config options here */
-};
-
-export default nextConfig;


### PR DESCRIPTION
## Summary
- replace the Next.js configuration with a CommonJS `next.config.js` that uses JSDoc typing and `@ts-check`
- update the Dockerfile to copy the new CommonJS config into the runtime image

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2c41a8c808323a07c1c0a14bbd504